### PR TITLE
Update `repository` property to link to this repo

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "src/index.js",
   "repository": {
     "type": "git",
-    "url": "https://github.com/jaysoo/react-native-parallax-listview"
+    "url": "https://github.com/jaysoo/react-native-parallax-scroll-view"
   },
   "files": [
     "src",


### PR DESCRIPTION
It seems this property is not using the new package name yet.
Thank you for building this component :+1: