### PR TITLE
Put background on top if renderParallaxHeader returns null

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ The `ParallaxScrollView` component adds a few additional properties, as describe
 
 | Property | Type | Required | Description |
 | -------- | ---- | -------- | ----------- |
-| `renderParallaxHeader` |  `func` | **Yes** |This renders the parallax header above the background. |
+| `renderParallaxHeader` |  `func` | **Yes** |This renders the parallax header above the background. If returns `null` the background will be on top.|
 | `parallaxHeaderHeight` | `number` | **Yes** |This is the height of parallax header. |
 | `headerBackgroundColor` | `string` | No | This is the background color of the sticky header, and also used as parallax header background color if `renderBackground` is not provided. (Defaults to `'#000'`) |
 | `contentBackgroundColor` | `string` | No | This is the background color of the content. (Defaults to `'#fff'`) |

--- a/src/index.js
+++ b/src/index.js
@@ -72,7 +72,7 @@ class ParallaxScrollView extends Component {
     return (
       <View style={[style, styles.container]}
             onLayout={(e) => this._maybeUpdateViewDimensions(e)}>
-        { background }
+        { renderParallaxHeader() && background }
         {
           React.cloneElement(scrollElement, {
               ref: SCROLLVIEW_REF,
@@ -81,6 +81,7 @@ class ParallaxScrollView extends Component {
               onScroll: this._onScroll.bind(this),
             },
             parallaxHeader,
+            renderParallaxHeader() ? null : background,
             bodyComponent,
             footerSpacer
           )


### PR DESCRIPTION
In some cases it might be nice to receive touch events on the background if `renderParallaxHeader()` returns null.  