### PR TITLE
Allow custom styles on content container

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -42,7 +42,8 @@ const IPropTypes = {
   renderForeground: func,
   renderScrollComponent: func,
   renderStickyHeader: func,
-  stickyHeaderHeight: number
+  stickyHeaderHeight: number,
+  contentContainerStyle: View.propTypes.style
 };
 
 class ParallaxScrollView extends Component {
@@ -80,12 +81,13 @@ class ParallaxScrollView extends Component {
       renderStickyHeader,
       stickyHeaderHeight,
       style,
+      contentContainerStyle,
       ...scrollViewProps
     } = this.props;
 
     const background = this._renderBackground({ fadeOutBackground, backgroundScrollSpeed, backgroundColor, parallaxHeaderHeight, stickyHeaderHeight, renderBackground });
     const foreground = this._renderForeground({ fadeOutForeground, parallaxHeaderHeight, stickyHeaderHeight, renderForeground: renderForeground || renderParallaxHeader });
-    const bodyComponent = this._wrapChildren(children, { contentBackgroundColor, stickyHeaderHeight });
+    const bodyComponent = this._wrapChildren(children, { contentBackgroundColor, stickyHeaderHeight, contentContainerStyle });
     const footerSpacer = this._renderFooterSpacer({ contentBackgroundColor });
     const maybeStickyHeader = this._maybeRenderStickyHeader({ parallaxHeaderHeight, stickyHeaderHeight, backgroundColor, renderFixedHeader, renderStickyHeader });
     const scrollElement = renderScrollComponent(scrollViewProps);
@@ -241,11 +243,16 @@ class ParallaxScrollView extends Component {
     );
   }
 
-  _wrapChildren(children, { contentBackgroundColor, stickyHeaderHeight }) {
+  _wrapChildren(children, { contentBackgroundColor, stickyHeaderHeight, contentContainerStyle }) {
     const { viewHeight } = this.state;
+    const containerStyles = [{backgroundColor: contentBackgroundColor}];
+
+    if(contentContainerStyle)
+      containerStyles.push(contentContainerStyle);
+
     return (
       <View
-        style={{ backgroundColor: contentBackgroundColor }}
+        style={containerStyles}
         onLayout={e => {
                 // Adjust the bottom height so we can scroll the parallax header all the way up.
                 const { nativeEvent: { layout: { height } } } = e;
@@ -322,7 +329,8 @@ ParallaxScrollView.defaultProps = {
   renderBackground: renderEmpty,
   renderParallaxHeader: renderEmpty, // Deprecated (will be removed in 0.18.0)
   renderForeground: null,
-  stickyHeaderHeight: 0
+  stickyHeaderHeight: 0,
+  contentContainerStyle: null
 };
 
 module.exports = ParallaxScrollView;


### PR DESCRIPTION
For a `<ScrollView>` tag, you can set the style with the `contentContainerStyle` property.

There's no equivalent for a `<ParallaxScrollView>` because there's no way to set the style of the `bodyComponent`. If you try to specify the property `contentContainerStyle` currently, it gets passed into the `<ScrollView>` which wraps the `foreground`, `bodyComponent` and the `footerSpacer` components, and applies to style to those tags instead of just the `bodyComponent`. There's I can't imagine a reason why you'd want to style in internal ScrollView, so I don't think this would be a breaking change.

This change allows me to add the styles `flexDirection` and `flexWrap` to the `bodyComponent` in order to create a grid view with items side by side, such as the example below. You can see the changes I made in the example my fork's [`testContainerStyles` branch](https://github.com/alaycock/react-native-parallax-scroll-view/tree/testContainerStyles).

<img width="423" alt="screen shot 2016-04-30 at 1 43 08 pm" src="https://cloud.githubusercontent.com/assets/894797/14938209/8b9d2e6a-0ed9-11e6-832c-136e42dd9015.png">