### PR TITLE
Update for React Native 0.25

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,11 +1,14 @@
-const React = require('react-native');
+const React = require('react');
+const ReactNative = require('react-native');
+
+const { Component } = React;
+
 const {
   Animated,
-  Component,
   Dimensions,
   ScrollView,
   View
-} = React;
+} = ReactNative;
 
 const styles = require('./styles');
 


### PR DESCRIPTION
Requiring React API from `react-native` is now deprecated in version 0.25.