### PR TITLE
Fixed: warnings on react-native 0.25.x

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,13 +1,12 @@
-const React = require('react-native');
-const {
+import React, { Component } from 'react';
+import {
   Animated,
-  Component,
   Dimensions,
   ScrollView,
   View
-} = React;
+} from 'react-native';
 
-const styles = require('./styles');
+import styles from './styles';
 
 const { bool, func, number, string } = React.PropTypes;
 

--- a/src/styles.js
+++ b/src/styles.js
@@ -1,4 +1,4 @@
-const StyleSheet = require('react-native').StyleSheet;
+import { StyleSheet } from 'react-native';
 
 const styles = StyleSheet.create({
   container: {


### PR DESCRIPTION
React-Native as of 0.25.x is deprecating .cloneElement() and .createElement(), instead suggesting we use those methods from the React package as opposed to React-Native.

This commit fixes those warnings and moves to es6 imports style.