### PR TITLE
fixed #25 (Events are not passed through to the foreground view if STICKY_HEADER_HEIGHT overlaps)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -276,15 +276,20 @@ class ParallaxScrollView extends Component {
     const { viewWidth, scrollY } = this.state;
     if (renderStickyHeader || renderFixedHeader) {
       const p = pivotPoint(parallaxHeaderHeight, stickyHeaderHeight);
+      let height = interpolate(scrollY, {
+        inputRange: [0, stickyHeaderHeight],
+        outputRange: [0, stickyHeaderHeight],
+        extrapolate: 'clamp'
+      });
       return (
-        <View style={[styles.stickyHeader, { width: viewWidth, ...(stickyHeaderHeight ? { height: stickyHeaderHeight } : null ) }]}>
+        <View style={[styles.stickyHeader, { width: viewWidth }]}>
           {
             renderStickyHeader
               ? (
                 <Animated.View
                   style={{
                   backgroundColor: backgroundColor,
-                  height: stickyHeaderHeight,
+                  height: height,
                   opacity: interpolate(scrollY, {
                     inputRange: [0, p],
                     outputRange: [0, 1],


### PR DESCRIPTION
fixed #25 (Events are not passed through to the foreground view if STICKY_HEADER_HEIGHT overlaps)